### PR TITLE
add API to create applications from Airtable [wip]

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,1 @@
+MONGODB_URI=mongodb://localhost:27017/race

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# VS Code files
+.vscode

--- a/models/Application.js
+++ b/models/Application.js
@@ -1,0 +1,37 @@
+import mongoose from "mongoose";
+
+const { Schema } = mongoose;
+
+const ApplicationSchema = new Schema({
+  author: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "Author",
+  },
+
+  submissionDate: { type: Date, default: Date.now },
+
+  // copied from Airtable
+  projectName: String,
+  shortPitch: String,
+  extendedPitch: String,
+  projectGoals: String,
+  leaderStatement: String,
+  projectURL: String,
+  additionalDetails: String,
+  referral: String,
+  hasReferral: mongoose.SchemaTypes.Boolean,
+  helpfulLinks: String,
+  helpfulUploads: mongoose.SchemaTypes.Mixed,
+  evidence: String,
+  background: String,
+  pitch: String,
+
+  ranking: Number,
+  votes: Number,
+
+  airtableRecordId: String, // to avoid duplicates
+});
+
+module.exports =
+  mongoose.models.Application ||
+  mongoose.model("Application", ApplicationSchema);

--- a/models/Author.js
+++ b/models/Author.js
@@ -1,0 +1,11 @@
+import mongoose from "mongoose";
+
+const AuthorSchema = new mongoose.Schema({
+  name: String,
+  email: String,
+  ethAddress: String,
+  discordUser: String,
+});
+
+module.exports =
+  mongoose.models.Author || mongoose.model("Author", AuthorSchema);

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@heroicons/react": "^1.0.5",
     "@web3-react/core": "^6.1.9",
     "@web3-react/injected-connector": "^6.0.7",
+    "mongoose": "^6.1.1",
     "next": "12.0.7",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/pages/api/applications/index.js
+++ b/pages/api/applications/index.js
@@ -1,0 +1,68 @@
+import Application from "../../../models/Application";
+import Author from "../../../models/Author";
+import dbConnect from "../../../utils/dbConnect";
+
+export default async function handler(req, res) {
+  await dbConnect();
+
+  if (req.method === "POST") {
+    const body = req.body;
+
+    let airtableRecordId = body.airtableRecordId;
+
+    let application = await Application.findOne({
+      airtableRecordId,
+    }).exec();
+
+    if (application) return res.status(200).send(application);
+
+    let authorEmail = body.email;
+    let author = await Author.findOne({ email: authorEmail }).exec();
+    let authorId;
+
+    if (!author) {
+      author = new Author({
+        email: authorEmail,
+        name: body["Name"],
+        ethAddress: body["Ethereum Address"],
+        discordUser: body["Discord User"] || "test#1234",
+      });
+      authorId = await author.save();
+    } else {
+      console.log("author exists", author);
+      authorId = author.id;
+    }
+
+    application = new Application({
+      author: authorId,
+      submissionDate: body.createdTime,
+
+      projectName: body["Project Name"],
+      shortPitch: body["Short Pitch"],
+      extendedPitch: body["Extended Pitch"],
+      projectGoals: body["Project Goals"],
+      leaderStatement: body["Leader Statement"],
+      projectURL: body["Project URL"],
+      additionalDetails: body["Additional Details"],
+      referral: body["Referral"],
+      hasReferral: body["Has Referal"],
+      helpfulLinks: body["Helpful Links"],
+      helpfulUploads: body["Helpful uploads"], // This one might be a bit trickier
+      evidence:
+        body["Please state evidence of exceptional ability for each founder"],
+      background: body["Provide some background on each founder"],
+      pitch: body["Pitch us your product"],
+
+      // As per discord message, adding some random numbers for testing
+      ranking: Math.floor(Math.random() * 100),
+      votes: Math.floor(Math.random() * 10),
+    });
+    let applicationId = await application.save();
+    return res.status(201).send(applicationId);
+  } else if (req.method === "GET") {
+    const applications = await Application.find().exec();
+    return res.status(200).send(applications);
+  } else {
+    res.status(405);
+  }
+}

--- a/utils/dbConnect.js
+++ b/utils/dbConnect.js
@@ -1,0 +1,15 @@
+import mongoose from "mongoose";
+
+const connection = {};
+
+async function dbConnect() {
+  if (connection.isConnected) {
+    return;
+  }
+
+  const db = await mongoose.connect(process.env.MONGODB_URI);
+
+  connection.isConnected = db.connections[0].readyState;
+}
+
+export default dbConnect;


### PR DESCRIPTION
This adds 2 new API routes for listing and creating applications:

```
GET /api/applications
POST /api/applications {"Name": "Tom", ...}
```

Airtable's field names are quite long and not really code-friendly. However, for now, I used their field names as they're stored so we can later create a trigger like "New form submitted" -> "Create DB application via API" without a lot of extra work.

Example application creation via API:
```
curl --request POST \
  --url http://localhost:3000/api/applications \
  --header 'Content-Type: application/json' \
  --data '{
	"airtableRecordId": "recDo4JABUFskLGFZ",
	"createdTime": "2021-12-10T13:55:09.000Z",
	"Name": "Tom Apple",
	"Email": "tom@example.org",
	"Ethereum Address": "tom.eth",
	"Project Name": "⚡📈 test",
	"Short Pitch": "Hyperscale testing: testing fast funding for web3.",
	"Extended Pitch": "Automated testing of ⚡📈 forms and primitives",
	"Project Goals": "Getting this proposal through the system",
	"Leader Statement": "Getting this proposal through the system",
	"Project URL": "⚡📈.eth",
	"Additional Details": "not required",
	"Referral": "(⚡,⚡)",
	"Has Referal": true
}'
```

**Disclaimer:** I mostly work with Python backends, so there might be some non-best practice things here. Please lmk what to improve 🙏 