### PR TITLE
Utilize healthchecks for startup order in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,9 @@ services:
     ports:
       - "3000:3000"
     depends_on:
-      - mongo
+      mongo:
+        condition: service_healthy
+
   mongo:
     container_name: mongo
     image: mongo
@@ -21,6 +23,11 @@ services:
       - ./data:/data/db
     ports:
       - "27017:27017"
+    healthcheck:
+      test: echo 'db.runCommand("ping").ok' | mongo localhost:27017 --quiet
+      interval: 1s
+      timeout: 10s
+      start_period: 5s
 
   mongo_seed:
     image: mongo
@@ -30,3 +37,6 @@ services:
       - ./:/usr/src/app
     command:
       /usr/src/app/mongo/import.sh
+    depends_on:
+      mongo:
+        condition: service_healthy


### PR DESCRIPTION
The easy way of determining startup order in docker-compose is somewhat limited. "For example, it doesn’t verify when a specific service is really ready." [1]

This PR implements an actual healthcheck on the mongodb and uses that for determining whether or not the db seeds and application can be started. This is probably not super crucial right now but can mitigate certain race conditions new developers could see.

[1] https://docs.docker.com/compose/startup-order/