### PR TITLE
Fix docker-compose restart and development with docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
-FROM node:14.17-alpine
+FROM node:14-alpine
 
 RUN apk update && apk add python3 g++ make && rm -rf /var/cache/apk/*
-RUN mkdir -p /home/app/ && chown -R node:node /home/app
-WORKDIR /home/app
-COPY --chown=node:node . .
+WORKDIR /usr/src/app
 
-USER node
+COPY package.json .
+RUN yarn --frozen-lockfile
+
 ENV MONGODB_URI "mongodb://mongo:27017/race"
-
-RUN yarn install --frozen-lockfile
-RUN yarn build
-
+COPY . .
+RUN yarn
 CMD ["yarn", "dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,6 @@ services:
     container_name: mongo
     image: mongo
     restart: always
-    volumes:
-      - ./data:/data/db
     ports:
       - "27017:27017"
     healthcheck:


### PR DESCRIPTION
* Remove mongodb data from populating inside source tree. We seed db
  every restart anyway.
* Now you can develop with docker-compose:
  * start the app and mongodb with: `docker-compose up -d`.
  * Modify source code and observe that localhost:3000 updates
    automatically.