### PR TITLE
Add firebase storage emulator for file upload development

### DIFF
--- a/.github/workflows/yarn-workflow.yml
+++ b/.github/workflows/yarn-workflow.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Build the stack
         run: |
           cp docker-compose.override.yml.ci docker-compose.override.yml
-          docker-compose up -d
+          docker-compose build web
           docker container ls
       - name: Lint
-        run: docker-compose exec -T web yarn lint
+        run: docker-compose run --no-deps web yarn lint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,16 @@ services:
       timeout: 10s
       start_period: 5s
 
+  firebase:
+    build:
+      context: emulators
+      dockerfile: Dockerfile.firebase
+    container_name: firebase
+    ports:
+      - 4000:4000
+      - 4400:4400
+      - 9199:9199
+
   web:
     build:
       context: .
@@ -25,8 +35,8 @@ services:
     ports:
       - 3000:3000
     depends_on:
-      mongo:
-        condition: service_healthy
+      - mongo
+      - firebase
     env_file:
       - .env.docker.example
 

--- a/emulators/Dockerfile.firebase
+++ b/emulators/Dockerfile.firebase
@@ -1,0 +1,14 @@
+FROM openjdk:16-slim-buster
+
+WORKDIR /app
+ADD emulators .
+
+RUN apt-get update; apt-get install -y curl \
+    && curl -sL https://deb.nodesource.com/setup_16.x | bash - \
+    && apt-get install -y nodejs \
+    && curl -L https://www.npmjs.com/install.sh | sh \
+    && npm install -g firebase-tools \
+    && firebase setup:emulators:storage
+
+CMD [ "firebase", "--project=race", "emulators:start", "--only", "storage" ]
+EXPOSE 4000 4400 9199

--- a/emulators/firebase.json
+++ b/emulators/firebase.json
@@ -1,0 +1,19 @@
+{
+  "storage": {
+    "rules": "storage.rules"
+  },
+  "emulators": {
+    "ui": {
+      "port": 4000,
+      "host": "0.0.0.0"
+    },
+    "hub": {
+      "port": 4400,
+      "host": "0.0.0.0"
+    },
+    "storage": {
+      "port": 9199,
+      "host": "0.0.0.0"
+    }
+  }
+}


### PR DESCRIPTION
Firebase Storage emulator is now part of dev environment:
 - endpoint: `firebase:9199`
 - project: `race`

```
:~/Repo/race$ curl -s localhost:4400/emulators | jq .
{
  "hub": {
    "name": "hub",
    "host": "0.0.0.0",
    "port": 4400
  },
  "ui": {
    "name": "ui",
    "host": "0.0.0.0",
    "port": 4000,
    "pid": 37
  },
  "logging": {
    "name": "logging",
    "host": "localhost",
    "port": 4500
  },
  "storage": {
    "name": "storage",
    "host": "0.0.0.0",
    "port": 9199
  }
}
```