### PR TITLE
Ignore package-lock.json files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# unused lockfiles
+package-lock.json
+
 # dependencies
 /node_modules
 /.pnp


### PR DESCRIPTION
We are using `yarn` in this project and are intentionally checking-in
`yarn.lock`. Some people seem to prefer using `npm` locally, but we don't want
the `package-lock.json` file to also be checked in. It's probably easier to just
ignore this file than to have this discussion in the respective pull requests :)

Example: https://github.com/hyper-scale/race/pull/93