### PR TITLE
Fix mongoose._id serialization error

### DIFF
--- a/actions/applications/index.js
+++ b/actions/applications/index.js
@@ -120,6 +120,7 @@ export async function getApplications(options = {}) {
         lastRank = lastRank + 1;
       }
       application.rank = lastRank;
+      application._id = application._id.toString();
     });
   }
   return aggregate ?? [];


### PR DESCRIPTION
Serialization of object `_id`s failed due to missing `toString` or `toJSON` implementation on the `mongoose.ObjectId` class. See https://github.com/vercel/next.js/issues/11993 for a reference.