### PR TITLE
Invalidate leaderboard cache when order changes

### DIFF
--- a/pages/dao-race/index.js
+++ b/pages/dao-race/index.js
@@ -67,7 +67,7 @@ export default function DaoRace({ order, projects }) {
             Most recent
           </button>
         </div>
-        <Leaderboard data={projects} />
+        <Leaderboard data={projects} key={order} />
 
         {/* <Spinner /> */}
       </Layout>


### PR DESCRIPTION
Votes and ranks didn't update when order changed because react was too good at caching.