### PR TITLE
Use JSON parse/stringify to avoid serialization issues in getServerSideProps

### DIFF
--- a/actions/applications/index.js
+++ b/actions/applications/index.js
@@ -120,7 +120,6 @@ export async function getApplications(options = {}) {
         lastRank = lastRank + 1;
       }
       application.rank = lastRank;
-      application._id = application._id.toString();
     });
   }
   return aggregate ?? [];

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -198,7 +198,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (_context) =>
   const projects = await getApplications({ limit: numRows });
   return {
     props: {
-      projects,
+      projects: JSON.parse(JSON.stringify(projects)),
     },
   };
 };


### PR DESCRIPTION
I am getting the same serialization error as in this PR
https://github.com/hyper-scale/race/pull/127 but with Date now.

I am proposing to use JSON parse/stringify to fix all cases. Maybe we
should use fetch and route /applications isntead?